### PR TITLE
Improving url regex correspondance with web standards

### DIFF
--- a/assemblyline_service_utilities/common/balbuzard/patterns.py
+++ b/assemblyline_service_utilities/common/balbuzard/patterns.py
@@ -212,10 +212,13 @@ class PatternMatch(object):
                 rb'HKLM|hkey_performance_data|hkey_users|HKPD|internet settings|\\sam|\\software|\\system|' \
                 rb'\\userinit)' \
                 rb'\\[-_A-Z0-9.\\ ]{1,200}\b'
-    PAT_URL = rb'(?i)(?:ftp|http|https)://(?:[A-Z0-9.-_:]*@)?' \
-              rb'[A-Z0-9.-]{1,}\.(?:XN--[A-Z0-9]{4,18}|[a-z]{2,12}|[0-9]{1,3})' \
-              rb'(?::[0-9]{1,5})?' \
-              rb'(?:/[A-Z0-9/\-\.&%\$#=~\?_+]{3,1000}){0,1}'
+    # $-/ is $%&'()*+,-./ of which $&'()*+, are subdelims and .- are unreserved
+    PAT_URL = (rb"(?i)(?:ftp|https?)://"  # scheme
+               rb"(?:[\w!$-.:;=~]{,2000}@)?"  # userinfo
+               rb"(?:[A-Z0-9.-]{4,253}|\[[0-9A-F:]{3,39}\])"  # hostname
+               rb"(?::[0-9]{0,5})?"  # port
+               rb"(?:[/?][\w!$-/:;=@?~]{,2000})?"  # path and or query
+               rb"(?:#[\w!$-/:;=@?~]*)?")  # fragment
     PAT_ANYHTTP = rb'(?i)http://' \
                   rb'[A-Z0-9.-]{6,}\.' \
                   rb'(?:XN--[A-Z0-9]{4,18}|[a-z]{2,12}|[0-9]{1,3})' \


### PR DESCRIPTION
Using a combination of RFC 3986 and RFC 1035 to rewrite regex
see https://datatracker.ietf.org/doc/html/rfc3986
and https://datatracker.ietf.org/doc/html/rfc1035

Sources for magic numbers are:
- 2000: internet explorer and edge cap url lengths at 2083
- {4,253} a.co, g.co are valid domains, 253 is longest allowed by DNS
- {3,39} only 2 length IPv6 is [::] and full length representation is 39
- {0,5} port can be empty and largest is 65535

Should fix https://cccs.atlassian.net/browse/AL-2611 and prevent related problems from happening