### PR TITLE
Allow # in fragment and prohibit url from ending with '),.

### DIFF
--- a/assemblyline_service_utilities/common/balbuzard/patterns.py
+++ b/assemblyline_service_utilities/common/balbuzard/patterns.py
@@ -226,9 +226,8 @@ class PatternMatch(object):
         rb"(?:[\w!$-.:;=~@]{,2000}@)?"  # userinfo
         rb"(?:[A-Z0-9.-]{4,253}|\[[0-9A-F:]{3,39}\])"  # hostname
         rb"(?::[0-9]{0,5})?"  # port
-        rb"(?:[/?][\w!$-/:;=@?~]{,2000})?"  # path and or query
-        rb"(?:#[\w!$-/:;=@?~]*)?"
-    )  # fragment
+        rb"(?:[/?#](?:[\w!#$-/:;=@?~]{,2000}[\w!#$%&(*+-/:;=@?~])?)?"  # path, query and fragment
+    )
     PAT_ANYHTTP = (
         rb"(?i)http://"
         rb"[A-Z0-9.-]{6,}\."

--- a/assemblyline_service_utilities/common/balbuzard/patterns.py
+++ b/assemblyline_service_utilities/common/balbuzard/patterns.py
@@ -226,7 +226,7 @@ class PatternMatch(object):
         rb"(?:[\w!$-.:;=~@]{,2000}@)?"  # userinfo
         rb"(?:[A-Z0-9.-]{4,253}|\[[0-9A-F:]{3,39}\])"  # hostname
         rb"(?::[0-9]{0,5})?"  # port
-        rb"(?:[/?#](?:[\w!#$-/:;=@?~]{,2000}[\w!#$%&(*+-/:;=@?~])?)?"  # path, query and fragment
+        rb"(?:[/?#](?:[\w!#$-/:;=@?~]{,2000}[\w!#$%&(*+\-/:;=@?~])?)?"  # path, query and fragment
     )
     PAT_ANYHTTP = (
         rb"(?i)http://"

--- a/test/balbuzard/test_patterns.py
+++ b/test/balbuzard/test_patterns.py
@@ -35,7 +35,8 @@ def test_PAT_DOMAIN(data, domain):
         b"https://www.google.com.account.login:.@example.com",
         b"https://@example.com",
         b"https://:@example.com",
-        b"https://google.com@micrsoft.com@adobe.com@example.com/path/to?param=value1&_param=value2&trailing_url=https%3A%2F%2Fmalicious.com",
+        b"https://google.com@micrsoft.com@adobe.com@example.com/path/to?param=value1&_param=value2"
+        b"&trailing_url=https%3A%2F%2Fmalicious.com",
         # Example URIs from https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Example_URIs
         b"https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top",
         b"http://[2001:db8::7]/c=GB?objectClass?one",

--- a/test/balbuzard/test_patterns.py
+++ b/test/balbuzard/test_patterns.py
@@ -45,3 +45,16 @@ def test_PAT_DOMAIN(data, domain):
 )
 def test_PAT_URL_basic_auth(url):
     assert re.match(PatternMatch.PAT_URL, url).span() == (0, len(url))
+
+
+@pytest.mark.parametrize(
+    ("url", "suffix_len"),
+    [
+        (b"function('https://example.com/')", 2),
+        (b"full sentence with a url https://example.com/.", 1),
+        (b"part of a phrase with a url https://example.com/,", 1),
+        (b"barefunction(https://example.com)", 1),
+    ],
+)
+def test_PAT_URL_in_context(url, suffix_len):
+    assert re.search(PatternMatch.PAT_URL, url).end() == len(url) - suffix_len

--- a/test/balbuzard/test_patterns.py
+++ b/test/balbuzard/test_patterns.py
@@ -55,6 +55,8 @@ def test_PAT_URL_basic_auth(url):
         (b"full sentence with a url https://example.com/.", 1),
         (b"part of a phrase with a url https://example.com/,", 1),
         (b"barefunction(https://example.com)", 1),
+        (b'in a string content "https://example.com"works.', 7),
+        (b"whitespaceless('https://example.com'){script;}", 11),
     ],
 )
 def test_PAT_URL_in_context(url, suffix_len):


### PR DESCRIPTION
Though only one `#` is ever allowed in a valid url per RFC 3986 the fragment is handled client side and web browsers will simply ignore all text after the first #. Potentially text after the first # could be relevant.

Allowing `#` in fragments allows the merging of the path, query and fragment

Added a guard to the end of the combined path/query/fragment to prevent urls from ending with `'),.`. Though nothing in the spec prevents urls containing those characters `'` and `)` are common context enders in scripts and `,` or `.` will often end a url in plain text. Fortunately the most common context `"` is already disallowed in urls.