### PR TITLE
Update dynamic_service_helper.py

### DIFF
--- a/assemblyline_service_utilities/common/dynamic_service_helper.py
+++ b/assemblyline_service_utilities/common/dynamic_service_helper.py
@@ -2042,7 +2042,7 @@ class OntologyResults:
         processes: List[Process] = [
             process
             for process in self.get_processes()
-            if process.pid == pid and timestamp <= process.end_time and timestamp >= process.start_time
+            if process.pid == pid and timestamp <= str(process.end_time) and timestamp >= str(process.start_time)
         ]
         if not processes:
             return None

--- a/test/test_dynamic_service_helper.py
+++ b/test/test_dynamic_service_helper.py
@@ -2221,7 +2221,16 @@ class TestOntologyResults:
         )
         default_or.add_process(p)
         assert default_or.get_process_by_pid_and_time(1, "1970-01-01 00:00:01.000") == p
-
+        p2 = default_or.create_process(
+            objectid=objectid,
+            image="blah",
+            pid=2,
+            start_time=1.0,
+            end_time=2.0,
+        )
+        default_or.add_process(p2)
+        assert default_or.get_process_by_pid_and_time(2, "1.0") == p2
+       
     @staticmethod
     def test_get_processes_by_pguid():
         default_or = OntologyResults(service_name="blah")


### PR DESCRIPTION
 and timestamp <= process.end_time
TypeError: '<=' not supported between instances of 'float' and 'str'