### PR TITLE
Prevent domain matches in windows paths

### DIFF
--- a/assemblyline_service_utilities/common/balbuzard/patterns.py
+++ b/assemblyline_service_utilities/common/balbuzard/patterns.py
@@ -194,7 +194,7 @@ class PatternMatch(object):
 
     # --- Regex Patterns -----------------------------------------------------------------------------------------------
 
-    PAT_DOMAIN = rb"(?i)\b(?:[A-Z0-9-]+\.)+(?:XN--[A-Z0-9]{4,18}|[A-Z]{2,12})(?![A-Z.-])"
+    PAT_DOMAIN = rb"(?i)(?<![-\w.\\])(?:[A-Z0-9-]+\.)+(?:XN--[A-Z0-9]{4,18}|[A-Z]{2,12})(?![A-Z.-])"
     PAT_FILECOM = (
         rb"(?i)(?:\b[a-z]?[:]?[- _A-Z0-9.\\~]{0,75}[%]?"
         rb"(?:ALLUSERPROFILE|APPDATA|commonappdata|CommonProgramFiles|HOMEPATH|LOCALAPPDATA|"


### PR DESCRIPTION
`C:\path\looks-like-a-domain.tld` can cause false positives because the match begins at the `\` character and sees `looks-like-a-domain.tld` as a domain. Not allowing matches to start after `\` `.` `-` and the `\w` set instead of just `\w` (`\b`) prevents domain matches in windows paths.
`-` is required else it would match `like-a-domain.tld`
`.` is required else `C:\path\looks.like.a.domain.tld` would match `like.a.domain.tld`