### PR TITLE
Monkeypatch assemblyline_v4_service.common.utils.DEVELOPMENT_MODE

### DIFF
--- a/assemblyline_service_utilities/testing/helper.py
+++ b/assemblyline_service_utilities/testing/helper.py
@@ -4,6 +4,7 @@ import re
 import shutil
 from pathlib import Path
 
+import assemblyline_v4_service.common.utils
 import pytest
 from assemblyline.common import forge
 from assemblyline.common.dict_utils import flatten
@@ -15,6 +16,8 @@ from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.task import Task
 from cart import unpack_file
 
+# Test in development mode
+assemblyline_v4_service.common.utils.DEVELOPMENT_MODE = True
 
 class FileMissing(Exception):
     pass


### PR DESCRIPTION
DEVELOPMENT_MODE is used to avoid certain calls that might fail in test or development situations. Patching it to True when using TestHelper.