### PR TITLE
Parse uri and use regex match instead of search for _validate_tag

### DIFF
--- a/assemblyline_service_utilities/common/dynamic_service_helper.py
+++ b/assemblyline_service_utilities/common/dynamic_service_helper.py
@@ -3251,22 +3251,23 @@ def extract_iocs_from_text_blob(
     for domain in sorted(domains):
         # If a domain matches one of the following criteria, ensure that it is the hostname of a URI, otherwise
         # we don't want it
+        domain_lower = domain.lower()
         if (
-            any(domain.lower().endswith(tld) for tld in COMMON_FP_TLDS)
+            any(domain_lower.endswith(tld) for tld in COMMON_FP_TLDS)
             or (enforce_char_min and len(domain) < MIN_DOMAIN_CHARS)
             or (enforce_domain_char_max and len(domain) > MAX_DOMAIN_CHARS)
         ):
             is_domain_present_in_uri = False
             for uri in uris:
                 parsed_uri = urlparse(uri.lower())
-                if domain == parsed_uri.hostname:
+                if domain_lower == parsed_uri.hostname:
                     is_domain_present_in_uri = True
                     break
 
             # If it does, then double check that the domain is not the domain of any URI
             if not is_domain_present_in_uri:
                 continue
-        elif domain.lower() in COMMON_FP_DOMAINS:
+        elif domain_lower in COMMON_FP_DOMAINS:
             continue
 
         # File names match the domain and URI regexes, so we need to avoid tagging them

--- a/test/test_tag_helper.py
+++ b/test/test_tag_helper.py
@@ -72,6 +72,10 @@ def test_get_regex_for_tag():
         ("network.static.uri", "http://blah.ca/blah", {"network.static.uri": ["http://blah.ca/blah"], "network.static.uri_path": ["/blah"]}, (True, False)),
         # Domain value tagged as URI
         ("network.static.uri", "www.blah.ca", {"network.static.domain": ["www.blah.ca"]}, (True, False)),
+        # URL with filename that can be misintrepreted as a domain
+        ("network.dynamic.uri", "https://127.0.0.1/c9k5y4.zip", {"network.dynamic.ip": ["127.0.0.1"], "network.dynamic.uri": ["https://127.0.0.1/c9k5y4.zip"], "network.dynamic.uri_path": ["/c9k5y4.zip"]}, (True, False)),
+        # URI path tagged as URI
+        ("network.dynamic.uri", "/c9k5y4.zip", {"network.dynamic.uri_path": ["/c9k5y4.zip"]}, (True, False)),
     ]
 )
 def test_validate_tag(tag, value, expected_tags, added_tag):


### PR DESCRIPTION
- domain and ip match only the uri hostname or full tag
- a uri_path being validated as uri is now tagged as uri_path
- fixed some lowercase issues
- added tests for filename domain false positives